### PR TITLE
Rounded search entry

### DIFF
--- a/data/res/style.css
+++ b/data/res/style.css
@@ -6,6 +6,14 @@
   font-size: smaller;
 }
 
+.rounded-entry {
+  border-radius: 999px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
 .searchbar .searchtag {
   background-color: alpha(currentColor, 0.1);
   border-radius: 100px;

--- a/data/ui/search_page.blp
+++ b/data/ui/search_page.blp
@@ -74,10 +74,16 @@ template $MusicusSearchPage: Adw.NavigationPage {
             }
           }
 
-          Gtk.SearchEntry search_entry {
-            placeholder-text: _("Enter composers, performers, works…");
-            margin-top: 24;
-            activate => $select() swapped;
+          Adw.Clamp {
+            Gtk.SearchEntry search_entry {
+              placeholder-text: _("Enter composers, performers, works…");
+              margin-top: 24;
+              activate => $select() swapped;
+
+              styles [
+                "rounded-entry"
+              ]
+            }
           }
 
           Gtk.Stack stack {


### PR DESCRIPTION
Also decrease the width a little.

Makes it more aesthetically pleasing in pages like in this case. For example Shortwave also uses a rounded search bar for its search page: https://flathub.org/apps/de.haeckerfelix.Shortwave

![Screenshot From 2025-05-16 09-30-07](https://github.com/user-attachments/assets/270c13c5-7e1f-4081-9963-6fc4c209e45e)
